### PR TITLE
Allow crated functions to find packages attached by `library()`

### DIFF
--- a/tests/testthat/helper-crate.R
+++ b/tests/testthat/helper-crate.R
@@ -1,6 +1,5 @@
 
 expect_data <- function(crate, ...) {
   nms <- env_names(fn_env(crate))
-  nms <- nms[nms != "library"]
   expect_true(all(nms %in% c(...)))
 }


### PR DESCRIPTION
Fixes #16.

This is a combination of a suggestion by @lionel- to deploy a shim for `library()` calls and an observation by @DavisVaughan that reattaching the crate to the Global Environment would put it back on the search path.

This is not the only way to fix this, but is a pretty simple solution.