### PR TITLE
Ensures `crate()` dots arguments are named

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,9 @@
   serialized by name rather than by value, the crate is still isolated from
   objects in the global environment (#16).
 
+* `crate()` now requires all `...` arguments to be named instead of silently
+  dropping unnamed arguments (#15).
+
 # carrier 0.1.1
 
 * Crated functions no longer carry source references (#6).

--- a/R/crate.R
+++ b/R/crate.R
@@ -81,6 +81,9 @@ crate <- function(.fn, ..., .parent_env = baseenv()) {
   # is in scope and new data is created in a separate child
   env <- child_env(caller_env())
   dots <- exprs(...)
+  if (!all(nzchar(names(dots)))) {
+    abort("All `...` arguments must be named")
+  }
   locally(!!!dots, .env = env)
 
   # Quote and evaluate in the local env to avoid capturing execution

--- a/R/crate.R
+++ b/R/crate.R
@@ -81,7 +81,7 @@ crate <- function(.fn, ..., .parent_env = baseenv()) {
   # is in scope and new data is created in a separate child
   env <- child_env(caller_env())
   dots <- exprs(...)
-  if (!all(nzchar(names(dots)))) {
+  if (!all(nzchar(names2(dots)))) {
     abort("All `...` arguments must be named")
   }
   locally(!!!dots, .env = env)

--- a/R/crate.R
+++ b/R/crate.R
@@ -34,9 +34,7 @@ NULL
 #'   you need to crate a function that is already defined. Formulas
 #'   are converted to purrr-like lambda functions using
 #'   [rlang::as_function()].
-#' @param ... Arguments to declare in the environment of `.fn`. If a
-#'   name is supplied, the object is assigned to that name. Otherwise
-#'   the argument is automatically named after itself.
+#' @param ... Named arguments to declare in the environment of `.fn`.
 #' @param .parent_env The default of `baseenv()` ensures that the evaluation
 #'   environment of the crate is isolated from the search path. Specifying
 #'   another environment such as the global environment allows this condition to

--- a/man/crate.Rd
+++ b/man/crate.Rd
@@ -13,9 +13,7 @@ you need to crate a function that is already defined. Formulas
 are converted to purrr-like lambda functions using
 \code{\link[rlang:as_function]{rlang::as_function()}}.}
 
-\item{...}{Arguments to declare in the environment of \code{.fn}. If a
-name is supplied, the object is assigned to that name. Otherwise
-the argument is automatically named after itself.}
+\item{...}{Named arguments to declare in the environment of \code{.fn}.}
 
 \item{.parent_env}{The default of \code{baseenv()} ensures that the evaluation
 environment of the crate is isolated from the search path. Specifying

--- a/tests/testthat/test-crate.R
+++ b/tests/testthat/test-crate.R
@@ -6,6 +6,15 @@ test_that("crate() supports lambda syntax", {
   )
 })
 
+test_that("crate() requires named `...` arguments", {
+  expect_error(
+    crate(function(x) identity(x), x = 1, y = 2, 3),
+    "arguments must be named"
+  )
+  expect_no_error(crate(function(x) identity(x), x = 1, y = 2))
+  expect_no_error(crate(function(x) identity(x)))
+})
+
 test_that("crate() requires functions", {
   expect_error(crate(1), "must evaluate to a function")
 })


### PR DESCRIPTION
Fixes #15.

Unnamed `...` supplied to `crate()` now errors.