### PR TITLE
Add `crate()` arguments for improved error messages

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,9 @@
 * `crate()` now requires all `...` arguments to be named instead of silently
   dropping unnamed arguments (#15).
 
+* `crate()` gains `.error_arg` and `.error_call` arguments to allow for better
+  error messages when calling `crate()` from other functions (#14).
+
 # carrier 0.1.1
 
 * Crated functions no longer carry source references (#6).

--- a/R/crate.R
+++ b/R/crate.R
@@ -40,6 +40,7 @@ NULL
 #'   another environment such as the global environment allows this condition to
 #'   be relaxed (but at the expense of no longer being able to rely on a local
 #'   run giving the same results as one in a different process).
+#' @inheritParams rlang::args_error_context
 #'
 #' @export
 #' @examples
@@ -76,7 +77,13 @@ NULL
 #' # explicitly set its environment to the crate environment with the
 #' # set_env() function from rlang:
 #' crate(rlang::set_env(fn))
-crate <- function(.fn, ..., .parent_env = baseenv()) {
+crate <- function(
+  .fn,
+  ...,
+  .parent_env = baseenv(),
+  .error_arg = ".fn",
+  .error_call
+) {
   # Evaluate arguments in a child of the caller so the caller context
   # is in scope and new data is created in a separate child
   env <- child_env(caller_env())
@@ -97,11 +104,17 @@ crate <- function(.fn, ..., .parent_env = baseenv()) {
   if (is_formula(fn)) {
     fn <- as_function(fn)
   } else if (!is_function(fn)) {
-    abort("`.fn` must evaluate to a function")
+    abort(
+      sprintf("`%s` must evaluate to a function", .error_arg),
+      call = .error_call
+    )
   }
 
   if (!is_reference(get_env(fn), env)) {
-    abort("The function must be defined inside the `crate()` call")
+    abort(
+      "The function must be defined inside this call",
+      call = .error_call
+    )
   }
 
   # Remove potentially heavy srcrefs (#6)

--- a/R/crate.R
+++ b/R/crate.R
@@ -82,7 +82,7 @@ crate <- function(
   ...,
   .parent_env = baseenv(),
   .error_arg = ".fn",
-  .error_call
+  .error_call = environment()
 ) {
   # Evaluate arguments in a child of the caller so the caller context
   # is in scope and new data is created in a separate child

--- a/man/crate.Rd
+++ b/man/crate.Rd
@@ -4,7 +4,7 @@
 \alias{crate}
 \title{Crate a function to share with another process}
 \usage{
-crate(.fn, ..., .parent_env = baseenv())
+crate(.fn, ..., .parent_env = baseenv(), .error_arg = ".fn", .error_call)
 }
 \arguments{
 \item{.fn}{A fresh formula or function. "Fresh" here means that
@@ -20,6 +20,15 @@ environment of the crate is isolated from the search path. Specifying
 another environment such as the global environment allows this condition to
 be relaxed (but at the expense of no longer being able to rely on a local
 run giving the same results as one in a different process).}
+
+\item{.error_arg}{An argument name as a string. This argument
+will be mentioned in error messages as the input that is at the
+origin of a problem.}
+
+\item{.error_call}{The execution environment of a currently
+running function, e.g. \code{caller_env()}. The function will be
+mentioned in error messages as the source of the error. See the
+\code{call} argument of \code{\link[rlang:abort]{abort()}} for more information.}
 }
 \description{
 \code{crate()} creates functions in a self-contained environment

--- a/man/crate.Rd
+++ b/man/crate.Rd
@@ -4,7 +4,13 @@
 \alias{crate}
 \title{Crate a function to share with another process}
 \usage{
-crate(.fn, ..., .parent_env = baseenv(), .error_arg = ".fn", .error_call)
+crate(
+  .fn,
+  ...,
+  .parent_env = baseenv(),
+  .error_arg = ".fn",
+  .error_call = environment()
+)
 }
 \arguments{
 \item{.fn}{A fresh formula or function. "Fresh" here means that


### PR DESCRIPTION
Closes #14 by adding `.error_arg` and `.error_call` at `crate()`.