### PR TITLE
Set all function closures to the local environment when crating

### DIFF
--- a/R/crate.R
+++ b/R/crate.R
@@ -101,6 +101,13 @@ crate <- function(
   # .parent_env = baseenv()
   env_poke_parent(env, .parent_env)
 
+  # Check and set all function closures to the local env
+  for (name in names(env)) {
+    if (is_closure(env[[name]])) {
+      environment(env[[name]]) <- env
+    }
+  }
+
   if (is_formula(fn)) {
     fn <- as_function(fn)
   } else if (!is_function(fn)) {


### PR DESCRIPTION
Fixes #27.

Both the [original reprex](https://github.com/tidyverse/purrr/issues/1200#issue-3222458470) reported for `purrr::in_parallel()`, and [existing solution](https://github.com/tidyverse/purrr/issues/1200#issuecomment-3061893103) work:


This PR has the additional benefit of not pulling in function closures and any large objects that may be in them. E.g.:
``` r
mirai::daemons(4)

fn <- function() {
  foo <- 1:1e8 + 0L
  do_it <- function(x) {
    object.size(foo)
  }
  purrr::map(
    1:2,
    purrr::in_parallel(function(x) do_it(x), do_it = do_it)
  )
}

fn()
#> Error in `purrr::map()`:
#> ℹ In index: 1.
#> Caused by error in `do_it()`:
#> ! object 'foo' not found
```

<sup>Created on 2025-08-19 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>

However this does mean that this (which currently works) now also fails:
``` r
mirai::daemons(4)

func <- function(x = 1:3) {
  fun_mother <- function(x) {
    x + fun_child(x)
  }
  fun_child <- function(x) { x + 2 }
  purrr::map(x, purrr::in_parallel(\(x) x + fun_mother(x), fun_mother = fun_mother))
}
func()
#> Error in `purrr::map()`:
#> ℹ In index: 1.
#> Caused by error in `fun_child()`:
#> ! could not find function "fun_child"
```

<sup>Created on 2025-08-19 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>