### PR TITLE
Set all global env function closures to the local env when crating

### DIFF
--- a/R/crate.R
+++ b/R/crate.R
@@ -101,6 +101,14 @@ crate <- function(
   # .parent_env = baseenv()
   env_poke_parent(env, .parent_env)
 
+  # Check and set global_env() function closures to the local env
+  for (name in names(env)) {
+    x <- env[[name]]
+    if (is_closure(x) && identical(environment(x), global_env())) {
+      environment(env[[name]]) <- env
+    }
+  }
+
   if (is_formula(fn)) {
     fn <- as_function(fn)
   } else if (!is_function(fn)) {


### PR DESCRIPTION
Fixes #27.

As with #28, both the [original reprex](https://github.com/tidyverse/purrr/issues/1200#issue-3222458470) reported for `purrr::in_parallel()`, and [existing solution](https://github.com/tidyverse/purrr/issues/1200#issuecomment-3061893103) work.

This PR takes a lighter-touch approach and only changes the closure for global environment functions.

This retains the undesirable footgun reprex behaviour, in that the closure is not stripped:

``` r
mirai::daemons(4)

fn <- function() {
  foo <- 1:1e8 + 0L
  do_it <- function(x) {
    object.size(foo)
  }
  purrr::map(
    1:2,
    purrr::in_parallel(function(x) do_it(x), do_it = do_it)
  )
}

fn()
#> [[1]]
#> 400000048 bytes
#> 
#> [[2]]
#> 400000048 bytes
```

<sup>Created on 2025-08-19 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>

But it also means that the following existing behaviour is retained:

``` r
mirai::daemons(4)

func <- function(x = 1:3) {
  fun_mother <- function(x) {
    x + fun_child(x)
  }
  fun_child <- function(x) { x + 2 }
  purrr::map(x, purrr::in_parallel(\(x) x + fun_mother(x), fun_mother = fun_mother))
}
func()
#> [[1]]
#> [1] 5
#> 
#> [[2]]
#> [1] 8
#> 
#> [[3]]
#> [1] 11
```

<sup>Created on 2025-08-19 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>

We only need to merge either this PR or #28.