### PR TITLE
Do not re-crate existing crates passed as additional arguments

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,10 +1,11 @@
 # carrier (development version)
 
-* All functions passed to `crate()` via `...` are now themselves crated. This
-  means that they must themselves be self-contained, with any objects they
-  depend upon also passed to `...`. This allows, for example, helper functions
-  to be more easily crated, and prevents inadvertently crating objects contained
-  within a function closure (#27).
+* All functions passed to `crate()` via `...` are now themselves crated, with
+  the exception that existing crates are not re-crated. This means that they
+  must themselves be self-contained, with any objects they depend upon also
+  passed to `...`. This allows, for example, helper functions to be more easily
+  crated, and prevents inadvertently crating objects contained within a function
+  closure (#27).
 
 # carrier 0.2.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,11 +1,11 @@
 # carrier (development version)
 
-* All functions passed to `crate()` via `...` are now themselves crated, with
-  the exception that existing crates are not re-crated. This means that they
-  must themselves be self-contained, with any objects they depend upon also
-  passed to `...`. This allows, for example, helper functions to be more easily
-  crated, and prevents inadvertently crating objects contained within a function
-  closure (#27).
+* All functions passed to `crate()` via `...` are now themselves crated. This
+  means that they must themselves be self-contained, with any objects they
+  depend upon also passed to `...`. This allows, for example, helper functions
+  to be more easily crated, and prevents inadvertently crating objects contained
+  within a function closure. Note that if an existing crate is supplied, this is
+  not re-crated (#27).
 
 # carrier 0.2.0
 

--- a/R/crate.R
+++ b/R/crate.R
@@ -29,12 +29,12 @@ NULL
 #' * They should declare any data they depend on. You can declare data
 #'   by supplying additional arguments or by unquoting objects with `!!`.
 #'
-#' * A function (closure) supplied as an additional argument is itself crated,
-#'   with the exception that existing crates are not re-crated. This means that
-#'   it must be self-contained by supplying all objects required by it as
-#'   further additional arguments, if not already supplied. Only functions
-#'   directly supplied to `...` are crated, and containers such as lists are not
-#'   recursively walked to find functions.
+#' * A function (closure) supplied as an additional argument is itself crated.
+#'   This means that it must be self-contained by supplying all objects required
+#'   by it as further additional arguments, if not already supplied. Only
+#'   functions directly supplied to `...` are crated, and containers such as
+#'   lists are not recursively walked to find functions. Note that if an
+#'   existing crate is supplied, this is not re-crated.
 #'
 #' @param .fn A fresh formula or function. "Fresh" here means that
 #'   they should be declared in the call to `crate()`. See examples if

--- a/R/crate.R
+++ b/R/crate.R
@@ -29,11 +29,12 @@ NULL
 #' * They should declare any data they depend on. You can declare data
 #'   by supplying additional arguments or by unquoting objects with `!!`.
 #'
-#' * A function (closure) supplied as an additional argument is itself crated.
-#'   This means that it must be self-contained by supplying all objects required
-#'   by it as further additional arguments, if not already supplied. Only
-#'   functions directly supplied to `...` are crated, and containers such as
-#'   lists are not recursively walked to find functions.
+#' * A function (closure) supplied as an additional argument is itself crated,
+#'   with the exception that existing crates are not re-crated. This means that
+#'   it must be self-contained by supplying all objects required by it as
+#'   further additional arguments, if not already supplied. Only functions
+#'   directly supplied to `...` are crated, and containers such as lists are not
+#'   recursively walked to find functions.
 #'
 #' @param .fn A fresh formula or function. "Fresh" here means that
 #'   they should be declared in the call to `crate()`. See examples if
@@ -107,10 +108,10 @@ crate <- function(
   # .parent_env = baseenv()
   env_poke_parent(env, .parent_env)
 
-  # Check and set all non-namespace function closures to the local env
+  # Set all non-namespace, non-crate function closures to the local env
   for (name in names(env)) {
     x <- env[[name]]
-    if (is_closure(x) && !isNamespace(environment(x))) {
+    if (is_closure(x) && !isNamespace(environment(x)) && !is_crate(x)) {
       environment(x) <- env
       env[[name]] <- zap_srcref(x)
     }

--- a/man/crate.Rd
+++ b/man/crate.Rd
@@ -63,7 +63,8 @@ by supplying additional arguments or by unquoting objects with \verb{!!}.
 This means that it must be self-contained by supplying all objects required
 by it as further additional arguments, if not already supplied. Only
 functions directly supplied to \code{...} are crated, and containers such as
-lists are not recursively walked to find functions.
+lists are not recursively walked to find functions. Note that if an
+existing crate is supplied, this is not re-crated.
 }
 }
 

--- a/tests/testthat/test-crate.R
+++ b/tests/testthat/test-crate.R
@@ -158,3 +158,9 @@ test_that("closures passed via `...` are not switched for package functions", {
   fn <- crate(function(x) format_bytes(x), format_bytes = format_bytes)
   expect_identical(fn(123), format_bytes(123))
 })
+
+test_that("crates passed to `...` are not re-crated", {
+  fn2 <- crate(function(x) format_bytes(x), format_bytes = format_bytes)
+  fn <- crate(function(x) fn2(x), fn2 = fn2)
+  expect_identical(fn(123), format_bytes(123))
+})


### PR DESCRIPTION
Amends behaviour of #28 to respect the integrity of crates passed to `...` of `crate()`.

Addresses the [revdep failure](https://github.com/r-lib/carrier/pull/32/commits/ce9ca7dd789409379c16c8502fb9f194c7e46b71#diff-bbdda7f28391ee0ec001638e5603609582124345e0d65ebd4747cc592f9bd56d) of dynparam, which relies on the use of nested crates.